### PR TITLE
Update build.sbt for use with Daffodil VSCode Extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+         {
+            "request": "launch",
+            "type": "dfdl",
+            "name": "test_01",
+            "schema": {
+                "path": "${workspaceFolder}/../envelope-payload/src/main/resources/io/github/dfdlschemas/envelopepayload/xsd/envelopePayload.dfdl.xsd",
+                "rootName": null,
+                "rootNamespace": null
+            },
+            "data": "${workspaceFolder}/../envelope-payload/src/test/resources/io/github/dfdlschemas/envelopepayload/test_01.dat",
+            "debugServer": 4711,
+            "infosetFormat": "xml",
+            "infosetOutput": {
+                "type": "file",
+                "path": "${workspaceFolder}/../envelope-payload/target/infoset.xml"
+            },
+            "tdmlConfig": {
+                "action": "generate",
+                "name": "undefined",
+                "description": "undefined",
+                "path": "undefined"
+            },
+            "trace": true,
+            "stopOnEntry": true,
+            "useExistingServer": false,
+            "openDataEditor": false,
+            "openInfosetView": false,
+            "openInfosetDiffView": false,
+            "daffodilDebugClasspath": [
+                "${workspaceFolder}/../envelope-payload/src/main/resources",
+                "${workspaceFolder}/../tcpMessage/src/main/resources",
+                "${workspaceFolder}/../mil-std-2045/src/main/resources",
+                "${workspaceFolder}/../PCAP/src/main/resources",
+                "${workspaceFolder}/../ethernetIP/src/main/resources",
+                "${workspaceFolder}/../envelope-payload/lib_managed/jars/com.owlcyberdefense/dfdl-ethernetip_2.12/dfdl-ethernetip_2.12-1.4.0.jar"
+            ],
+            "dataEditor": {
+                "port": 9000,
+                "logging": {
+                    "file": "${workspaceFolder}/../envelope-payload/dataEditor-${omegaEditPort}.log",
+                    "level": "info"
+                }
+            },
+            "dfdlDebugger": {
+                "logging": {
+                    "file": "${workspaceFolder}/../envelope-payload/daffodil-debugger.log",
+                    "level": "INFO"
+                }
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## DFDL Schema: envelope-payload example
 
-This is an _assembly schema_ which glues together three _component schemas_. 
+This is an _assembly schema_ which glues together several _component schemas_. 
 
-These are a tcp header schema, a second header schema, mil-std-2045, and a payload schema, PCAP. 
+These are a tcp message header schema, a second header schema, mil-std-2045, and a payload schema, PCAP. 
 
 This idiom, where an envelope or header is used in conjunction with a payload, and the two are defined separately, 
 illustrates how they can be mixed and matched, and reused without copying and modifying either of them. 
@@ -13,6 +13,44 @@ This schema includes tests of the three when combined.
 
 An additional wrinkle is that the PCAP DFDL schema uses yet another component schema, ethernetIP.dfdl.xsd, so the PCAP 
 schema it both itself an assembly schema, and a component for this schema. 
+
+Furthermore, the ethernetIP schema defines and uses a Daffodil _layer plugin_ to compute the IPv4 packet checksum.
+This requires that the jar file containing that layer plugin code class files is on the classpath. 
+
+## Using this DFDL Schema at the Daffodil Command Line Interface(CLI)
+
+Setup of the class path for a schema with all these components is difficult, but fortunately
+we can get the *sbt* tool to do the work for us.
+
+Executing this shell script (on linux) will define the `DAFFODIL_CLASSPATH` that the CLI needs:
+
+    export DAFFODIL_CLASSPATH=$(sbt -batch -error "export fullClasspath")
+
+## Using this DFDL Schema with the Daffodil VSCode Extension 
+
+Setup of the launch.json for a schema with all these components is difficult. 
+
+This project includes a `.vscode/launch.json` file which can be used as a template or to run a 
+simple test under the VSCode Daffodil debugger. 
+
+This assumes all 5 github DFDLSchemas projects:
+
+- envelope-payload
+- tcpMessage
+- mil-std-2045
+- PCAP
+- ethernetIP
+
+are `git` cloned into adjacent peer directories so that relative paths 
+used in the `.vscode/launch.json` can navigate between the different schemas. 
+
+The jar for the ethernetIP schema's Daffodil layer plugin is assumed to appear in the `lib_managed`
+directory, which is populated by issuing an `sbt` command in the envelope-payload root directory such as:
+
+    sbt test
+
+or 
+    sbt updateClassifiers
 
 
 ## Copyright and Licensing

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,14 @@ organization := "io.github.dfdlschemas"
 
 version := "1.1.0"
 
-daffodilVersion := "3.9.0"
+//
+// Final assembly DFDL schemas should be setup to create a lib_managed baseDirectory
+// This makes it easy to provide tools access to the required dependency jar files.
+//
+retrieveManaged := true
+
+useCoursier := false // because of bug, retrieveManaged won't work without this
+
 
 libraryDependencies ++= Seq(
   "io.github.dfdlschemas" % "dfdl-tcpmessage" % "1.1.0",


### PR DESCRIPTION
Normally we would not commit an IDE-specific file, but this one is so tedious to properly create that it has to be saved. 